### PR TITLE
Change accelerometer API so object can have the resolution set at instantiation

### DIFF
--- a/lib/accelerometer.js
+++ b/lib/accelerometer.js
@@ -3,6 +3,7 @@ var utils = require('./util');
 
 var accel_address = 0x19;
 var accel_device = '/dev/i2c-1'
+var resolution = 0x40;
 
 function Accelerometer(options) {
     if (options && options.address) {
@@ -10,6 +11,9 @@ function Accelerometer(options) {
     }
     if (options && options.device) {
         accel_device = options.device;
+    }
+    if (options && options.resolution) {
+        resolution = options.resolution;
     }
     this.accel = new i2c(accel_address, {
         device: accel_device,
@@ -29,7 +33,7 @@ Accelerometer.prototype.init = function(){
     });
 }
 Accelerometer.prototype.setResolution = function(){
-    this.accel.writeBytes(0x23, [0x38], function(err) {
+    this.accel.writeBytes(0x23, [resolution], function(err) {
         if(err){
             console.log("Error Setting Accelerometer Resolution : "+err);
         }


### PR DESCRIPTION
Hey Pranesh,

Thanks for sharing your work on your node-lsm303 library.  

Just offering a PR for allowing the resolution of the accelerometer to be set by the user at instantiation.  I changed the default resolution to -/+2Gauss in line with the spec sheet recommendations.  This gave me more meaningful readings, but feel free to change if you wish.

Here is the spec sheet I used
http://www.st.com/content/ccc/resource/technical/document/application_note/e6/f0/fa/af/94/5e/43/de/CD00269797.pdf/files/CD00269797.pdf/jcr:content/translations/en.CD00269797.pdf

Cheers,
Damo.
