### PR TITLE
Fix transposed properties from buffToXYZMag method

### DIFF
--- a/example/cal.js
+++ b/example/cal.js
@@ -1,4 +1,4 @@
-var lsm303 = require('node-lsm303');
+var lsm303 = require('../index');
 var ls  = new lsm303();
 
 var axesTemp = {}, headingTemp = {};

--- a/example/example1.js
+++ b/example/example1.js
@@ -1,4 +1,4 @@
-var lsm303 = require('lsm303');
+var lsm303 = require('../index.js');
 
 var ls  = new lsm303();
 
@@ -10,6 +10,7 @@ accel.readAxes(function(err,axes){
         console.log("Error reading Accelerometer Axes : " + err);
     }
     if (axes) {
+        console.log('Accelerometer') ;
         console.log(axes);
     }
 });
@@ -19,6 +20,7 @@ mag.readAxes(function(err,axes){
         console.log("Error reading Magnetometer Axes : " + err);
     }
     if (axes) {
+        console.log('Magnetometer') ;
         console.log(axes);
     }
 });
@@ -28,6 +30,7 @@ mag.readTemp(function(err,temp){
         console.log("Error reading Temperature : " + err);
     }
     if (temp) {
+        console.log('Temperature') ;
         console.log(temp);
     }
 });

--- a/example/readheading.js
+++ b/example/readheading.js
@@ -1,4 +1,4 @@
-var lsm303 = require('node-lsm303');
+var lsm303 = require('../index.js');
 var ls  = new lsm303();
 
 var axesTemp = {}, headingTemp = {};

--- a/lib/accelerometer.js
+++ b/lib/accelerometer.js
@@ -3,6 +3,7 @@ var utils = require('./util');
 
 var accel_address = 0x19;
 var accel_device = '/dev/i2c-1'
+var resolution = 0x40;
 
 function Accelerometer(options) {
     if (options && options.address) {
@@ -10,6 +11,9 @@ function Accelerometer(options) {
     }
     if (options && options.device) {
         accel_device = options.device;
+    }
+    if (options && options.resolution) {
+        resolution = options.resolution;
     }
     this.accel = new i2c(accel_address, {
         device: accel_device,
@@ -29,7 +33,7 @@ Accelerometer.prototype.init = function(){
     });
 }
 Accelerometer.prototype.setResolution = function(){
-    this.accel.writeBytes(0x23, [0x38], function(err) {
+    this.accel.writeBytes(0x23, [resolution], function(err) {
         if(err){
             console.log("Error Setting Accelerometer Resolution : "+err);
         }

--- a/lib/util.js
+++ b/lib/util.js
@@ -47,8 +47,8 @@ Utils.buffToXYZMag = function(buffer){
   var pos;
   pos = {
     x: (this.twoscomp((buffer[0] << 8) | buffer[1],16) - this.x_offset),
-    z: (this.twoscomp((buffer[2] << 8) | buffer[3],16) - this.z_offset),
-    y: (this.twoscomp((buffer[4] << 8) | buffer[5],16) - this.y_offset)
+    y: (this.twoscomp((buffer[2] << 8) | buffer[3],16) - this.y_offset),
+    z: (this.twoscomp((buffer[4] << 8) | buffer[5],16) - this.z_offset)
   };
   return pos;
 }


### PR DESCRIPTION
Hey Pranesh,

Another quick PR.  

The property values for y and z were transposed by mistake in this method.  This is  corrected in this commit.